### PR TITLE
[1.18.x]Fix getNearbyBlocks(Effected on work Chopping, Fishing, Harvesting)

### DIFF
--- a/common/src/main/java/mca/entity/ai/TaskUtils.java
+++ b/common/src/main/java/mca/entity/ai/TaskUtils.java
@@ -30,6 +30,7 @@ public interface TaskUtils {
     static List<BlockPos> getNearbyBlocks(BlockPos origin, World world, @Nullable Predicate<BlockState> filter, int xzDist, int yDist) {
         return BlockPos.streamOutwards(origin, xzDist, yDist, xzDist)
                 .filter(pos -> !origin.equals(pos) && (filter == null || filter.test(world.getBlockState(pos))))
+                .map(BlockPos::toImmutable)
                 .toList();
     }
 


### PR DESCRIPTION
If player trying to make villagers do chores, they aren't working, just standing idle.
It seems didn't written via issues yet, but here is someone already commented about the same problem: (https://www.curseforge.com/minecraft/mc-mods/minecraft-comes-alive-reborn?comment=376)

Why it happened:
The function 'TaskUtils:getNearbyBlocks' return a list and insided elements' values (and address) is all same when it exists.
and I realized that function uses vanilla code 'BlockPos.streamOutwards:iterateOutwards' and that code was written with mutable iterator.
so I just map to Immutable before do toList,

and now villagers are working with no problems.

I am not familiar with Java so I'm not sure about this is the right way to fix that bugs,
but anyway its working now so creates this pull request
If you are ok then please check it

* and also there is the same problem with 1.18 branch. (1.16 is ok because getNearbyBlocks creates a new BlockPos)