### PR TITLE
[1.18.x] Change tree found logic on ChoppingTask

### DIFF
--- a/common/src/main/java/mca/Config.java
+++ b/common/src/main/java/mca/Config.java
@@ -76,6 +76,7 @@ public final class Config implements Serializable {
     public int heartsForPardonHit = 30;
     public int pardonPlayerTicks = 1200;
     public boolean guardsTargetMonsters = false;
+    public int maxTreeHeightForChopping = 8; //and 30(about logs) is max height of largest trees
     public Map<String, Integer> guardsTargetEntities = ImmutableMap.<String, Integer>builder()
             .put("minecraft:creeper", -1)
             .put("minecraft:drowned", 2)

--- a/common/src/main/java/mca/entity/ai/brain/tasks/chore/ChoppingTask.java
+++ b/common/src/main/java/mca/entity/ai/brain/tasks/chore/ChoppingTask.java
@@ -1,6 +1,7 @@
 package mca.entity.ai.brain.tasks.chore;
 
 import com.google.common.collect.ImmutableMap;
+import mca.Config;
 import mca.entity.VillagerEntityMCA;
 import mca.entity.ai.Chore;
 import mca.entity.ai.TaskUtils;

--- a/common/src/main/java/mca/entity/ai/brain/tasks/chore/ChoppingTask.java
+++ b/common/src/main/java/mca/entity/ai/brain/tasks/chore/ChoppingTask.java
@@ -103,7 +103,7 @@ public class ChoppingTask extends AbstractChoreTask {
         super.keepRunning(world, villager, time);
     }
 
-    private final static int TREE_LOGS_MAX_HEIGHT = 10; //and 30(about logs) is max height of largest trees
+    private final static int TREE_LOGS_MAX_HEIGHT = 8; //and 30(about logs) is max height of largest trees
 
     /**
      * Returns trues if origin is bottom point of tree.

--- a/common/src/main/java/mca/entity/ai/brain/tasks/chore/ChoppingTask.java
+++ b/common/src/main/java/mca/entity/ai/brain/tasks/chore/ChoppingTask.java
@@ -103,8 +103,6 @@ public class ChoppingTask extends AbstractChoreTask {
         super.keepRunning(world, villager, time);
     }
 
-    private final static int TREE_LOGS_MAX_HEIGHT = 8; //and 30(about logs) is max height of largest trees
-
     /**
      * Returns trues if origin is bottom point of tree.
      */
@@ -119,7 +117,8 @@ public class ChoppingTask extends AbstractChoreTask {
 
         // check upside continues and valid leaves exist.
         BlockPos.Mutable pos_up = origin.mutableCopy(); // copy as mutable for reduce resources
-        for (int y = 0; y < TREE_LOGS_MAX_HEIGHT; y++) {
+        int maxTreeHeight = Config.getInstance().maxTreeHeightForChopping;
+        for (int y = 0; y < maxTreeHeight; y++) {
             BlockState up = world.getBlockState(pos_up.setY(pos_up.getY() + 1)); // use set directly instead of "pos_up.move(Direction.UP)" (set is faster)
             if (up.isIn(BlockTags.LOGS)) continue;
             else if (up.isIn(BlockTags.LEAVES)) return true;


### PR DESCRIPTION
When villagers do chopping tasks, they are recognized as trees even they're houses or farms' logs when leaves exist in y5, x1 distance.
It happened sometimes when trees spawned too closer to village's farms or houses, and then chopping tasks destroy them.

This codes make sure to villagers recognize only trees where leave exists on top log.
and in normal cases, this code might be faster than original code.

and it don't recognize very tall trees (ex: jungle trees) like the original code.
you can simply edit recognizable tree height via TREE_LOGS_MAX_HEIGHT

If you are ok then please check it

* and also there is same issue with 1.18 branch. (I thinks 1.16 has the same issues but that is LTS version right?)