### PR TITLE
Display villager's chore label back

### DIFF
--- a/common/src/main/java/mca/entity/VillagerEntityMCA.java
+++ b/common/src/main/java/mca/entity/VillagerEntityMCA.java
@@ -16,6 +16,7 @@ import mca.ParticleTypesMCA;
 import mca.SoundsMCA;
 import mca.TagsMCA;
 import mca.advancement.criterion.CriterionMCA;
+import mca.entity.ai.Chore;
 import mca.entity.ai.BreedableRelationship;
 import mca.entity.ai.Genetics;
 import mca.entity.ai.Memories;
@@ -953,7 +954,11 @@ public class VillagerEntityMCA extends VillagerEntity implements VillagerLike<Vi
         if (getVillagerBrain() != null) {
             MoveState state = getVillagerBrain().getMoveState();
             if (state != MoveState.MOVE) {
-                name = name.shallowCopy().append(" (").append(getVillagerBrain().getMoveState().getName()).append(")");
+                name = name.shallowCopy().append(" (").append(state.getName()).append(")");
+            }
+            Chore chore = getVillagerBrain().getCurrentJob();
+            if (chore != Chore.NONE) {
+                name = name.shallowCopy().append(" (").append(chore.getName()).append(")");
             }
         }
 


### PR DESCRIPTION
Is there any reason for displaying current chore label disabled? or this feature dose not anymore supported after MCA became to Reborn?
for this localization key is exist in json and getName function exist, but it seems not used anymore

<img width="428" alt="displayChoreLabels" src="https://user-images.githubusercontent.com/17191898/161958925-831351b5-b1cb-471a-a448-437798ee5e48.png">

If there is any reason about don't display this, please ignore this pr. thanks 😊