### PR TITLE
Extension altar pillar height to summon grim

### DIFF
--- a/common/src/main/java/mca/Config.java
+++ b/common/src/main/java/mca/Config.java
@@ -69,7 +69,7 @@ public final class Config implements Serializable {
     public int maxBuildingSize = 8192;
     public int maxBuildingRadius = 320;
     public int maxTreeHeight = 8;
-    public int summonGrimReaperAltarMaxPillarHeight = 8; // Less than 2 will be overridden.
+    public int minPillarHeight = 2;
     public Map<String, Integer> maxTreeTicks = ImmutableMap.<String, Integer>builder()
             .put("#minecraft:logs", 60)
             .build();

--- a/common/src/main/java/mca/Config.java
+++ b/common/src/main/java/mca/Config.java
@@ -69,6 +69,7 @@ public final class Config implements Serializable {
     public int maxBuildingSize = 8192;
     public int maxBuildingRadius = 320;
     public int maxTreeHeight = 8;
+    public int summonGrimReaperAltarMaxPillarHeight = 8; // Less than 2 will be overridden.
     public Map<String, Integer> maxTreeTicks = ImmutableMap.<String, Integer>builder()
             .put("#minecraft:logs", 60)
             .build();

--- a/common/src/main/java/mca/server/ReaperSpawner.java
+++ b/common/src/main/java/mca/server/ReaperSpawner.java
@@ -137,7 +137,7 @@ public class ReaperSpawner {
     }
 
     private Set<BlockPos> getTotemsFires(World world, BlockPos pos) {
-        int maxPillarHeight = Math.max(2, Config.getInstance().summonGrimReaperAltarMaxPillarHeight); // overridden to 2 if it less than 2.
+        int maxPillarHeight = Math.min(Config.getInstance().minPillarHeight, world.getTopY() - pos.getY());
         // use mutableCopy for reduce memories, and starts with the grounds
         BlockPos.Mutable target = new BlockPos.Mutable();
         return Stream.of(HORIZONTALS).map(d -> target.set(pos).setY(pos.getY() - 2).move(d, 3)).filter(ground -> {

--- a/common/src/main/java/mca/server/ReaperSpawner.java
+++ b/common/src/main/java/mca/server/ReaperSpawner.java
@@ -137,16 +137,17 @@ public class ReaperSpawner {
     }
 
     private Set<BlockPos> getTotemsFires(World world, BlockPos pos) {
-        int maxPillarHeight = Math.min(Config.getInstance().minPillarHeight, world.getTopY() - pos.getY());
-        // use mutableCopy for reduce memories, and starts with the grounds
+        int groundY = pos.getY() - 2;
+        int leftSkyHeight = world.getTopY() - groundY;
+        int minPillarHeight = Math.min(Config.getInstance().minPillarHeight, leftSkyHeight);
         BlockPos.Mutable target = new BlockPos.Mutable();
-        return Stream.of(HORIZONTALS).map(d -> target.set(pos).setY(pos.getY() - 2).move(d, 3)).filter(ground -> {
-            for (int curHeight = 1; curHeight <= maxPillarHeight + 1; curHeight++) {
-                ground.setY(ground.getY() + 1);
-                if (world.getBlockState(ground).isOf(Blocks.OBSIDIAN)) {
+        return Stream.of(HORIZONTALS).map(d -> target.set(pos).setY(groundY).move(d, 3)).filter(pillarPos -> {
+            for (int height = 1; height <= leftSkyHeight; height++) {
+                pillarPos.setY(groundY + height);
+                if (world.getBlockState(pillarPos).isOf(Blocks.OBSIDIAN)) {
                     continue;
-                } else if (world.getBlockState(ground).isIn(BlockTags.FIRE)) {
-                    return curHeight - 1 >= 2; // except fire tags
+                } else if (world.getBlockState(pillarPos).isIn(BlockTags.FIRE)) {
+                    return height - 1 >= minPillarHeight; // except fire one height
                 } else {
                     return false;
                 }


### PR DESCRIPTION
From The book "Death, and How to Cure It!"
-"To summon him, you must build an altar consisting of 3 obsidian columns that are at least 2 blocks high. They may be higher if you like."

It's written with "They may be higher if you like." but **actually altar height only works with 2 heights**.

This code makes workable altar height can be higher (can edit with config.java)

I know this is a very minor issue.
but anyway, this issue can be fixed simply so I create this pr.

If you are ok then please check.