### PR TITLE
Fix divideAndAdd() parsing "max" as Int

### DIFF
--- a/common/src/main/java/mca/entity/interaction/gifts/GiftPredicate.java
+++ b/common/src/main/java/mca/entity/interaction/gifts/GiftPredicate.java
@@ -38,7 +38,7 @@ public class GiftPredicate {
                         / (json.has("dividend") ? json.get("dividend").getAsFloat() : 1.0f)
                         + (json.has("add") ? json.get("add").getAsFloat() : 0.0f),
                 0.0f,
-                json.has("max") ? json.get("max").getAsInt() : 1.0f
+                json.has("max") ? json.get("max").getAsFloat() : 1.0f
         );
     }
 


### PR DESCRIPTION
Fixes forced floor when parsing datapacks.
Examples were in flirt and kiss dialogs where the hearts condition had their max floored to 1.0 even when set to 1.5.