### PR TITLE
Fix deadlock issue with reaper spawn

### DIFF
--- a/common/src/main/java/net/mca/server/ReaperSpawner.java
+++ b/common/src/main/java/net/mca/server/ReaperSpawner.java
@@ -64,14 +64,20 @@ public class ReaperSpawner {
             return;
         }
 
-        //make sure the chunks are loaded
-        //should fix deadlock issues we were facing
+        // Make sure the neighboring chunks are loaded
+        // Fixes deadlock issues with getBlockState() below
         ServerChunkManager manager = world.getChunkManager();
-        int range = 4;
-        if (!(manager.isChunkLoaded((pos.getX() - range) >> 4, (pos.getZ() - range) >> 4) &&
-                manager.isChunkLoaded((pos.getX() + range) >> 4, (pos.getZ() - range) >> 4) &&
-                manager.isChunkLoaded((pos.getX() - range) >> 4, (pos.getZ() + range) >> 4) &&
-                manager.isChunkLoaded((pos.getX() + range) >> 4, (pos.getZ() + range) >> 4))) {
+        int chunkX = pos.getX() >> 4;
+        int chunkZ = pos.getZ() >> 4;
+        if (!(manager.isChunkLoaded(chunkX, chunkZ) &&
+                manager.isChunkLoaded(chunkX - 1, chunkZ - 1) &&
+                manager.isChunkLoaded(chunkX - 2, chunkZ - 2) &&
+                manager.isChunkLoaded(chunkX - 1, chunkZ - 2) &&
+                manager.isChunkLoaded(chunkX - 2, chunkZ - 1) &&
+                manager.isChunkLoaded(chunkX + 1, chunkZ + 1) &&
+                manager.isChunkLoaded(chunkX + 2, chunkZ + 2) &&
+                manager.isChunkLoaded(chunkX + 2, chunkZ + 1) &&
+                manager.isChunkLoaded(chunkX + 1, chunkZ + 2))) {
             return;
         }
 


### PR DESCRIPTION
Crash Report:

[crash-2023-07-23_15.07.16-server.txt](https://github.com/Luke100000/minecraft-comes-alive/files/12141114/crash-2023-07-23_15.07.16-server.txt)

Properly check neighboring chunks are loaded 
