### PR TITLE
Make traits not hardcoded

### DIFF
--- a/common/src/main/java/net/mca/client/gui/VillagerEditorScreen.java
+++ b/common/src/main/java/net/mca/client/gui/VillagerEditorScreen.java
@@ -440,7 +440,7 @@ public class VillagerEditorScreen extends Screen implements SkinListUpdateListen
     }
 
     private Traits.Trait[] getValidTraits() {
-        return Arrays.stream(Traits.Trait.values()).filter(e -> {
+        return (Traits.Trait.values().stream()).filter(e -> {
             if (villagerUUID.equals(playerUUID)) {
                 return (Config.getInstance().bypassTraitRestrictions || e.isUsableOnPlayer()) && e.isEnabled();
             }

--- a/common/src/main/java/net/mca/client/render/layer/FaceLayer.java
+++ b/common/src/main/java/net/mca/client/render/layer/FaceLayer.java
@@ -39,7 +39,7 @@ public class FaceLayer<T extends LivingEntity, M extends BipedEntityModel<T>> ex
         int index = (int) Math.min(FACE_COUNT - 1, Math.max(0, CommonVillagerModel.getVillager(villager).getGenetics().getGene(Genetics.FACE) * FACE_COUNT));
         int time = villager.age / 2 + (int) (CommonVillagerModel.getVillager(villager).getGenetics().getGene(Genetics.HEMOGLOBIN) * 65536);
         boolean blink = time % 50 == 1 || time % 57 == 1 || villager.isSleeping() || villager.isDead();
-        boolean hasHeterochromia = variant.equals("normal") && CommonVillagerModel.getVillager(villager).getTraits().hasTrait(Traits.Trait.HETEROCHROMIA);
+        boolean hasHeterochromia = variant.equals("normal") && CommonVillagerModel.getVillager(villager).getTraits().hasTrait(Traits.HETEROCHROMIA);
         String gender = CommonVillagerModel.getVillager(villager).getGenetics().getGender().getDataName();
         String blinkTexture = blink ? "_blink" : (hasHeterochromia ? "_hetero" : "");
 

--- a/common/src/main/java/net/mca/client/render/layer/HairLayer.java
+++ b/common/src/main/java/net/mca/client/render/layer/HairLayer.java
@@ -60,7 +60,7 @@ public class HairLayer<T extends LivingEntity, M extends BipedEntityModel<T>> ex
 
     @Override
     public float[] getColor(T villager, float tickDelta) {
-        if (getVillager(villager).getTraits().hasTrait(Traits.Trait.RAINBOW)) {
+        if (getVillager(villager).getTraits().hasTrait(Traits.RAINBOW)) {
             return getRainbow(villager, tickDelta);
         }
 
@@ -69,7 +69,7 @@ public class HairLayer<T extends LivingEntity, M extends BipedEntityModel<T>> ex
             return hairDye;
         }
 
-        float albinism = getVillager(villager).getTraits().hasTrait(Traits.Trait.ALBINISM) ? 0.1f : 1.0f;
+        float albinism = getVillager(villager).getTraits().hasTrait(Traits.ALBINISM) ? 0.1f : 1.0f;
 
         return ColorPalette.HAIR.getColor(
                 getVillager(villager).getGenetics().getGene(Genetics.EUMELANIN) * albinism,

--- a/common/src/main/java/net/mca/client/render/layer/SkinLayer.java
+++ b/common/src/main/java/net/mca/client/render/layer/SkinLayer.java
@@ -25,7 +25,7 @@ public class SkinLayer<T extends LivingEntity, M extends BipedEntityModel<T>> ex
 
     @Override
     public float[] getColor(T villager, float tickDelta) {
-        float albinism = getVillager(villager).getTraits().hasTrait(Traits.Trait.ALBINISM) ? 0.1f : 1.0f;
+        float albinism = getVillager(villager).getTraits().hasTrait(Traits.ALBINISM) ? 0.1f : 1.0f;
 
         return ColorPalette.SKIN.getColor(
                 getVillager(villager).getGenetics().getGene(Genetics.MELANIN) * albinism,

--- a/common/src/main/java/net/mca/entity/VillagerEntityMCA.java
+++ b/common/src/main/java/net/mca/entity/VillagerEntityMCA.java
@@ -807,7 +807,7 @@ public class VillagerEntityMCA extends VillagerEntity implements VillagerLike<Vi
             }
 
             // sirben noises
-            if (this.age % 60 == 0 && random.nextInt(50) == 0 && traits.hasTrait(Traits.Trait.SIRBEN)) {
+            if (this.age % 60 == 0 && random.nextInt(50) == 0 && traits.hasTrait(Traits.SIRBEN)) {
                 sendChatToAllAround("sirben");
             }
 
@@ -1049,7 +1049,7 @@ public class VillagerEntityMCA extends VillagerEntity implements VillagerLike<Vi
             }
 
             //sirben
-            if (random.nextBoolean() && getTraits().hasTrait(Traits.Trait.SIRBEN)) {
+            if (random.nextBoolean() && getTraits().hasTrait(Traits.SIRBEN)) {
                 return SoundsMCA.SIRBEN.get();
             }
 
@@ -1424,7 +1424,7 @@ public class VillagerEntityMCA extends VillagerEntity implements VillagerLike<Vi
 
     @Override
     public void onStruckByLightning(ServerWorld world, LightningEntity lightning) {
-        getTraits().addTrait(Traits.Trait.ELECTRIFIED);
+        getTraits().addTrait(Traits.ELECTRIFIED);
     }
 
     @Override

--- a/common/src/main/java/net/mca/entity/VillagerLike.java
+++ b/common/src/main/java/net/mca/entity/VillagerLike.java
@@ -145,9 +145,9 @@ public interface VillagerLike<E extends Entity & VillagerLike<E>> extends CTrack
      * @return the set of "valid" genders
      */
     default Set<Gender> getAttractedGenderSet(VillagerLike<?> villager) {
-        if (villager.getTraits().hasTrait(Traits.Trait.BISEXUAL)) {
+        if (villager.getTraits().hasTrait(Traits.BISEXUAL)) {
             return Set.of(Gender.MALE, Gender.FEMALE, Gender.NEUTRAL);
-        } else if (villager.getTraits().hasTrait(Traits.Trait.HOMOSEXUAL)) {
+        } else if (villager.getTraits().hasTrait(Traits.HOMOSEXUAL)) {
             return Set.of(villager.getGenetics().getGender(), Gender.NEUTRAL);
         } else {
             return Set.of(villager.getGenetics().getGender().opposite(), Gender.NEUTRAL);
@@ -163,7 +163,7 @@ public interface VillagerLike<E extends Entity & VillagerLike<E>> extends CTrack
     }
 
     default Hand getDominantHand() {
-        return getTraits().hasTrait(Traits.Trait.LEFT_HANDED) ? Hand.OFF_HAND : Hand.MAIN_HAND;
+        return getTraits().hasTrait(Traits.LEFT_HANDED) ? Hand.OFF_HAND : Hand.MAIN_HAND;
     }
 
     default Hand getOpposingHand() {

--- a/common/src/main/java/net/mca/entity/ai/Traits.java
+++ b/common/src/main/java/net/mca/entity/ai/Traits.java
@@ -10,42 +10,70 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.random.Random;
 
-import java.util.Arrays;
-import java.util.Locale;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class Traits {
     private static final CDataParameter<NbtCompound> TRAITS = CParameter.create("traits", new NbtCompound());
 
-    public enum Trait {
-        LEFT_HANDED(1.0f, 0.5f, false),
-        COLOR_BLIND(1.0f, 0.5f),
-        HETEROCHROMIA(1.0f, 2.0f),
-        LACTOSE_INTOLERANCE(1.0f, 1.0f),
-        COELIAC_DISEASE(1.0f, 1.0f, false), // TODO: Implement for 7.4
-        DIABETES(1.0f, 1.0f, false), // TODO: Implement for 7.4
-        DWARFISM(1.0f, 1.0f),
-        ALBINISM(1.0f, 1.0f),
-        VEGETARIAN(1.0f, 0.0f, false), // TODO: Implement for 7.4
-        BISEXUAL(1.0f, 0.0f),
-        HOMOSEXUAL(1.0f, 0.0f),
-        ELECTRIFIED(0.0f, 0.0f, false),
-        SIRBEN(0.025f, 1.0f, true),
-        RAINBOW(0.05f, 0.0f);
+    public static final List<Trait> TRAIT_LIST = new ArrayList<>();
 
+    public static Trait LEFT_HANDED = registerTrait("left_handed", 1.0F, 0.5F, false);
+    public static Trait COLOR_BLIND = registerTrait("color_blind", 1.0F, 0.5F);
+    public static Trait HETEROCHROMIA = registerTrait("heterochromia", 1.0F, 0.5F);
+    public static Trait LACTOSE_INTOLERANCE = registerTrait("lactose_intolerance", 1.0F, 1.0F);
+    public static Trait COELIAC_DISEASE = registerTrait("coeliac_disease", 1.0F, 1.0F, false); // TODO: Implement for 7.4
+    public static Trait DIABETES = registerTrait("diabetes", 1.0F, 1.0F, false); // TODO: Implement for 7.4
+    public static Trait DWARFISM = registerTrait("dwarfism", 1.0F, 1.0F);
+    public static Trait ALBINISM = registerTrait("albinism", 1.0F ,1.0F);
+    public static Trait VEGETARIAN = registerTrait("vegetarian", 1.0F, 1.0F, false); // TODO: Implement for 7.4
+    public static Trait BISEXUAL = registerTrait("bisexual", 1.0F, 0.0F);
+    public static Trait HOMOSEXUAL = registerTrait("homosexual", 1.0F, 0.0F);
+    public static Trait ELECTRIFIED = registerTrait("electrified", 0.0F, 0.0F, false);
+    public static Trait SIRBEN = registerTrait("sirben", 0.025F, 1.0F, true);
+    public static Trait RAINBOW = registerTrait("rainbow", 0.05F, 0.0F);
+
+    public static Trait registerTrait(String id, float chance, float inherit, boolean usableOnPlayer) {
+        Trait trait = new Trait(id, chance, inherit, usableOnPlayer);
+        TRAIT_LIST.add(trait);
+        return trait;
+    }
+    public static Trait registerTrait(String id, float chance, float inherit) {
+        Trait trait = new Trait(id, chance, inherit);
+        TRAIT_LIST.add(trait);
+        return trait;
+    }
+
+    public static class Trait {
+        private final String id;
         private final float chance;
         private final float inherit;
         private final boolean usableOnPlayer;
 
-        Trait(float chance, float inherit, boolean usableOnPlayer) {
+        Trait(String id, float chance, float inherit, boolean usableOnPlayer) {
+            this.id = id;
             this.chance = chance;
             this.inherit = inherit;
             this.usableOnPlayer = usableOnPlayer;
         }
 
-        Trait(float chance, float inherit) {
-            this(chance, inherit, true);
+        Trait(String id, float chance, float inherit) {
+            this(id, chance, inherit, true);
+        }
+
+        public String name() {
+            return this.id;
+        }
+
+        public static List<Trait> values() {
+            return TRAIT_LIST;
+        }
+
+        public static Trait valueOf(String id) {
+            for (Trait t : TRAIT_LIST) {
+                if (t.name().equals(id)) return t;
+            }
+            return null;
         }
 
         public Text getName() {
@@ -94,7 +122,10 @@ public class Traits {
     }
 
     public boolean hasTrait(String trait) {
-        return hasTrait(entity, Trait.valueOf(trait.toUpperCase(Locale.ROOT)));
+        if (Trait.valueOf(trait) != null ) {
+            return hasTrait(entity, Trait.valueOf(trait));
+        }
+        return false;
     }
 
     public boolean eitherHaveTrait(Trait trait, VillagerLike<?> other) {
@@ -119,7 +150,7 @@ public class Traits {
 
     //initializes the genes with random numbers
     public void randomize() {
-        float total = (float)Arrays.stream(Trait.values()).mapToDouble(tr -> tr.chance).sum();
+        float total = (float)Trait.values().stream().mapToDouble(tr -> tr.chance).sum();
         for (Trait t : Trait.values()) {
             float chance = Config.getInstance().traitChance / total * t.chance;
             if (random.nextFloat() < chance && t.isEnabled()) {
@@ -142,10 +173,10 @@ public class Traits {
     }
 
     public float getVerticalScaleFactor() {
-        return hasTrait(Trait.DWARFISM) ? 0.65f : 1.0f;
+        return hasTrait(Traits.DWARFISM) ? 0.65f : 1.0f;
     }
 
     public float getHorizontalScaleFactor() {
-        return hasTrait(Trait.DWARFISM) ? 0.85f : 1.0f;
+        return hasTrait(Traits.DWARFISM) ? 0.85f : 1.0f;
     }
 }

--- a/common/src/main/java/net/mca/item/SirbenBabyItem.java
+++ b/common/src/main/java/net/mca/item/SirbenBabyItem.java
@@ -20,7 +20,7 @@ public class SirbenBabyItem extends BabyItem {
     @Override
     protected VillagerEntityMCA birthChild(ItemStack stack, ServerWorld world, ServerPlayerEntity player) {
         VillagerEntityMCA child = super.birthChild(stack, world, player);
-        child.getTraits().addTrait(Traits.Trait.SIRBEN);
+        child.getTraits().addTrait(Traits.SIRBEN);
         return child;
     }
 }

--- a/common/src/main/java/net/mca/mixin/MixinMilkBucketItem.java
+++ b/common/src/main/java/net/mca/mixin/MixinMilkBucketItem.java
@@ -20,7 +20,7 @@ public class MixinMilkBucketItem {
     public void onFinishedUsing(ItemStack stack, World world, LivingEntity user, CallbackInfoReturnable<ItemStack> cir) {
         VillagerLike<?> villagerLike = world.isClient ? CommonVillagerModel.getVillager(user) : VillagerLike.toVillager(user);
         if (villagerLike != null) {
-            if (villagerLike.getTraits().hasTrait(Traits.Trait.LACTOSE_INTOLERANCE)) {
+            if (villagerLike.getTraits().hasTrait(Traits.LACTOSE_INTOLERANCE)) {
                 user.addStatusEffect(new StatusEffectInstance(StatusEffects.POISON, 100, 0));
             }
         }


### PR DESCRIPTION
Converted the Trait enum to a class with a TRAIT_LIST arraylist for calling its values (added register method to automatically add them when defining them). This will make it much easier for possible addon mods and other mods to add their own traits to MCA as enums are not easily modifiable once defined. 