### PR TITLE
Fix edge case where the tombstone doesn't have a block entity causing repeated crash.

### DIFF
--- a/common/src/main/java/net/mca/block/TombstoneBlock.java
+++ b/common/src/main/java/net/mca/block/TombstoneBlock.java
@@ -280,7 +280,7 @@ public class TombstoneBlock extends BlockWithEntity implements Waterloggable {
     public List<ItemStack> getDroppedStacks(BlockState state, LootContextParameterSet.Builder builder) {
         List<ItemStack> stacks = super.getDroppedStacks(state, builder);
 
-        Optional<Data> data = Data.of(builder.get(LootContextParameters.BLOCK_ENTITY)).filter(Data::hasEntity);
+        Optional<Data> data = Data.of(builder.getOptional(LootContextParameters.BLOCK_ENTITY)).filter(Data::hasEntity);
 
         data
                 .flatMap(Data::getEntityName)


### PR DESCRIPTION
In the rare case that a tombstone doesn't have a block entity, due to some mod interaction or another, the server will permanently crash loop when the player joins.  

`Data#of` can handle null values so this should work fine.