### PR TITLE
Player2/OpenAIChat actions

### DIFF
--- a/common/src/main/java/net/mca/Config.java
+++ b/common/src/main/java/net/mca/Config.java
@@ -107,7 +107,8 @@ public final class Config implements Serializable {
     @SuppressWarnings("unused")
     public String _read_this_before_using_villager_ai = "https://github.com/Luke100000/minecraft-comes-alive/wiki/GPT3-based-conversations";
     public boolean enableVillagerChatAI = false;
-    public String villagerChatAIEndpoint = "https://api.conczin.net/v1/mca/chat";
+    public String villagerChatAIEndpoint = "http://127.0.0.1:4315/v1/chat/completions";
+    public boolean villagerChatAIUseTools = true;
     public String villagerChatAIToken = "";
     public String villagerChatAIModel = "default";
     public String villagerChatAISystemPrompt = "";

--- a/common/src/main/java/net/mca/entity/VillagerEntityMCA.java
+++ b/common/src/main/java/net/mca/entity/VillagerEntityMCA.java
@@ -498,6 +498,15 @@ public class VillagerEntityMCA extends VillagerEntity implements VillagerLike<Vi
         }
     }
 
+    public boolean tryBeginTradeWith(PlayerEntity customer) {
+        boolean hasOffers = !getOffers().isEmpty();
+        if (!hasOffers) {
+            return false;
+        }
+        copiedBeginTradeWith(customer);
+        return true;
+    }
+
     private void copiedBeginTradeWith(PlayerEntity customer) {
         this.copiedPrepareOffersFor(customer);
         this.setCustomer(customer);

--- a/common/src/main/java/net/mca/entity/VillagerEntityMCA.java
+++ b/common/src/main/java/net/mca/entity/VillagerEntityMCA.java
@@ -473,7 +473,7 @@ public class VillagerEntityMCA extends VillagerEntity implements VillagerLike<Vi
             if (isBaby()) {
                 copiedSayNo();
             } else {
-                boolean hasOffers = !getOffers().isEmpty();
+                boolean hasOffers = hasTradeOffers();
                 if (hand == Hand.MAIN_HAND) {
                     if (!hasOffers && !getWorld().isClient) {
                         copiedSayNo();
@@ -498,13 +498,12 @@ public class VillagerEntityMCA extends VillagerEntity implements VillagerLike<Vi
         }
     }
 
-    public boolean tryBeginTradeWith(PlayerEntity customer) {
-        boolean hasOffers = !getOffers().isEmpty();
-        if (!hasOffers) {
-            return false;
-        }
+    public boolean hasTradeOffers() {
+        return !getOffers().isEmpty();
+    }
+
+    public void beginTradeWith(PlayerEntity customer) {
         copiedBeginTradeWith(customer);
-        return true;
     }
 
     private void copiedBeginTradeWith(PlayerEntity customer) {

--- a/common/src/main/java/net/mca/entity/ai/chatAI/OpenAIChatAI.java
+++ b/common/src/main/java/net/mca/entity/ai/chatAI/OpenAIChatAI.java
@@ -10,7 +10,6 @@ import net.mca.entity.VillagerEntityMCA;
 import net.mca.entity.ai.chatAI.inworldAIModules.TriggerCommandInfo;
 import net.mca.entity.ai.chatAI.inworldAIModules.TriggerModule;
 import net.mca.entity.ai.chatAI.modules.*;
-import net.minecraft.server.command.TriggerCommand;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.HoverEvent;
@@ -64,8 +63,6 @@ public class OpenAIChatAI implements ChatAIStrategy {
         String message = map.has("choices") ? map.getAsJsonArray("choices").get(0).getAsJsonObject().getAsJsonObject("message").getAsJsonPrimitive("content").getAsString() : null;
         String error = map.has("error") ? map.get("error").getAsString().trim().replace("\n", " ") : null;
 
-        message = message == null ? null : cleanupAnswer(message);
-
         if (message != null) {
             // Parse json further, potentially
             message = message.replaceAll("```", "");
@@ -77,14 +74,13 @@ public class OpenAIChatAI implements ChatAIStrategy {
             }
         }
 
-        System.out.println("ASDF message: " + message);
-
         StructuredResponse structuredReply;
         try {
             structuredReply = new Gson().fromJson(message, StructuredResponse.class);
         } catch (JsonSyntaxException e) {
             e.printStackTrace();
             // just treat the message as normal
+            message = message == null ? null : cleanupAnswer(message);
             structuredReply = new StructuredResponse(message, "");
         }
 
@@ -250,12 +246,8 @@ public class OpenAIChatAI implements ChatAIStrategy {
                 token = variables.get("player");
             }
 
-            System.out.println("ASDF POST: " + body.toString());
-
             // encode and create url
             Answer message = post(config.villagerChatAIEndpoint, body.toString(), token);
-
-            System.out.println("ASDF got answer: " + message);
 
             if (message.error == null) {
                 // remember

--- a/common/src/main/java/net/mca/entity/ai/chatAI/OpenAIChatAI.java
+++ b/common/src/main/java/net/mca/entity/ai/chatAI/OpenAIChatAI.java
@@ -1,11 +1,16 @@
 package net.mca.entity.ai.chatAI;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 import net.mca.Config;
 import net.mca.MCA;
 import net.mca.entity.VillagerEntityMCA;
+import net.mca.entity.ai.chatAI.inworldAIModules.TriggerCommandInfo;
+import net.mca.entity.ai.chatAI.inworldAIModules.TriggerModule;
 import net.mca.entity.ai.chatAI.modules.*;
+import net.minecraft.server.command.TriggerCommand;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.HoverEvent;
@@ -34,7 +39,11 @@ public class OpenAIChatAI implements ChatAIStrategy {
         return phrase.replace("_", " ").toLowerCase(Locale.ROOT).replace("mca.", "");
     }
 
-    public record Answer(String answer, String error) {
+    public record StructuredResponse(String message, String optionalCommand) {
+
+    }
+
+    public record Answer(StructuredResponse answer, String error) {
     }
 
     private static HttpURLConnection getHttpURLConnection(String url, String token) throws IOException {
@@ -50,6 +59,38 @@ public class OpenAIChatAI implements ChatAIStrategy {
         return con;
     }
 
+    private static Answer parseAnswer(String body) {
+        JsonObject map = JsonParser.parseString(body).getAsJsonObject();
+        String message = map.has("choices") ? map.getAsJsonArray("choices").get(0).getAsJsonObject().getAsJsonObject("message").getAsJsonPrimitive("content").getAsString() : null;
+        String error = map.has("error") ? map.get("error").getAsString().trim().replace("\n", " ") : null;
+
+        message = message == null ? null : cleanupAnswer(message);
+
+        if (message != null) {
+            // Parse json further, potentially
+            message = message.replaceAll("```", "");
+            int bracketStart = message.indexOf("{");
+            int bracketEnd = message.lastIndexOf("}");
+            if (bracketEnd > bracketStart && bracketStart != -1 && bracketEnd != -1) {
+                // We have json! Include the brackets.
+                message = message.substring(bracketStart, bracketEnd + 1);
+            }
+        }
+
+        System.out.println("ASDF message: " + message);
+
+        StructuredResponse structuredReply;
+        try {
+            structuredReply = new Gson().fromJson(message, StructuredResponse.class);
+        } catch (JsonSyntaxException e) {
+            e.printStackTrace();
+            // just treat the message as normal
+            structuredReply = new StructuredResponse(message, "");
+        }
+
+        return new Answer(structuredReply, error);
+    }
+
     public static Answer post(String url, String requestBody, String token) {
         try {
             HttpURLConnection con = getHttpURLConnection(url, token);
@@ -63,14 +104,7 @@ public class OpenAIChatAI implements ChatAIStrategy {
             InputStream response = con.getInputStream();
             String body = IOUtils.toString(response, StandardCharsets.UTF_8);
 
-            // parse json
-            JsonObject map = JsonParser.parseString(body).getAsJsonObject();
-            String message = map.has("choices") ? map.getAsJsonArray("choices").get(0).getAsJsonObject().getAsJsonObject("message").getAsJsonPrimitive("content").getAsString() : null;
-            String error = map.has("error") ? map.get("error").getAsString().trim().replace("\n", " ") : null;
-
-            message = message == null ? null : cleanupAnswer(message);
-
-            return new Answer(message, error);
+            return parseAnswer(body);
         } catch (Exception e) {
             MCA.LOGGER.error(e);
             return new Answer(null, "Unknown error, check log!");
@@ -85,12 +119,7 @@ public class OpenAIChatAI implements ChatAIStrategy {
             InputStream response = con.getInputStream();
             String body = IOUtils.toString(response, StandardCharsets.UTF_8);
 
-            // parse json
-            JsonObject map = JsonParser.parseString(body).getAsJsonObject();
-            String answer = map.has("answer") ? map.get("answer").getAsString().trim().replace("\n", " ") : "";
-            String error = map.has("error") ? map.get("error").getAsString().trim().replace("\n", " ") : null;
-
-            return new Answer(answer, error);
+            return parseAnswer(body);
         } catch (Exception e) {
             MCA.LOGGER.error(e);
             return new Answer(null, "unknown");
@@ -177,13 +206,29 @@ public class OpenAIChatAI implements ChatAIStrategy {
                 sb.append("Match the language of the player, and use ").append(MCA.language).append(" when unsure.");
             }
 
+            // structure and commands
+            List<TriggerCommandInfo> validCommands;
+            if (config.villagerChatAIUseTools) {
+                validCommands = TriggerModule.triggerCommands;
+            } else {
+                validCommands = List.of();
+            }
+            String structureExample = new Gson().toJson(new StructuredResponse("example message to say", !validCommands.isEmpty() ? validCommands.get(0).command : ""));
+            sb.append("The reply MUST be in this JSON format: ").append(structureExample).append("\n");
+            sb.append("The following commands are valid:\n");
+            for (TriggerCommandInfo command : validCommands) {
+                sb.append("    ").append(command.command).append(": ").append(command.description).append("\n");
+            }
+
             String system = sb.toString();
 
             // construct body
             StringBuilder body = new StringBuilder();
             body.append("{");
             body.append("\"model\": \"").append(config.villagerChatAIModel).append("\",");
+            // START Messages
             body.append("\"messages\": [");
+            // System Message
             body.append("{\"role\": \"system\", \"content\": ").append(jsonStringQuote(system)).append("},");
             for (Pair<String, String> pair : pastDialogue) {
                 String role = pair.getLeft();
@@ -193,8 +238,11 @@ public class OpenAIChatAI implements ChatAIStrategy {
                         .append("\", \"name\": \"").append(name)
                         .append("\", \"content\": ").append(jsonStringQuote(content)).append("},");
             }
+            // User Message
             body.append("{\"role\": \"user\", \"name\": \"").append(playerName).append("\", \"content\": ").append(jsonStringQuote(msg)).append("}");
-            body.append("]}");
+            // END Messages
+            body.append("]");
+            body.append("}");
 
             // get access token
             String token = config.villagerChatAIToken;
@@ -202,16 +250,20 @@ public class OpenAIChatAI implements ChatAIStrategy {
                 token = variables.get("player");
             }
 
+            System.out.println("ASDF POST: " + body.toString());
+
             // encode and create url
             Answer message = post(config.villagerChatAIEndpoint, body.toString(), token);
+
+            System.out.println("ASDF got answer: " + message);
 
             if (message.error == null) {
                 // remember
                 if (message.answer != null) {
                     pastDialogue.add(new Pair<>("user", msg));
-                    pastDialogue.add(new Pair<>("assistant", message.answer));
+                    pastDialogue.add(new Pair<>("assistant", message.answer.message));
                 }
-                return Optional.ofNullable(message.answer);
+                return Optional.ofNullable(message.answer != null ? message.answer.message : null);
             } else if (message.error.equals("invalid_model")) {
                 player.sendMessage(Text.literal("Invalid model!").formatted(Formatting.RED), false);
             } else if (message.error.equals("limit")) {

--- a/common/src/main/java/net/mca/entity/ai/chatAI/OpenAIChatAI.java
+++ b/common/src/main/java/net/mca/entity/ai/chatAI/OpenAIChatAI.java
@@ -63,6 +63,8 @@ public class OpenAIChatAI implements ChatAIStrategy {
         String message = map.has("choices") ? map.getAsJsonArray("choices").get(0).getAsJsonObject().getAsJsonObject("message").getAsJsonPrimitive("content").getAsString() : null;
         String error = map.has("error") ? map.get("error").getAsString().trim().replace("\n", " ") : null;
 
+        System.out.println("parseAnswer got: " + body);
+
         if (message != null) {
             // Parse json further, potentially
             message = message.replaceAll("```", "");
@@ -202,18 +204,20 @@ public class OpenAIChatAI implements ChatAIStrategy {
                 sb.append("Match the language of the player, and use ").append(MCA.language).append(" when unsure.");
             }
 
-            // structure and commands
+            // structure and commands (if available)
             List<TriggerCommandInfo> validCommands;
             if (config.villagerChatAIUseTools) {
-                validCommands = TriggerModule.triggerCommands;
+                validCommands = TriggerModule.triggerCommands.stream().filter(c -> c.isActive == null || c.isActive.test(player, villager)).toList();
             } else {
                 validCommands = List.of();
             }
-            String structureExample = new Gson().toJson(new StructuredResponse("example message to say", !validCommands.isEmpty() ? validCommands.get(0).command : ""));
-            sb.append("The reply MUST be in this JSON format: ").append(structureExample).append("\n");
-            sb.append("The following commands are valid:\n");
-            for (TriggerCommandInfo command : validCommands) {
-                sb.append("    ").append(command.command).append(": ").append(command.description).append("\n");
+            if (!validCommands.isEmpty()) {
+                String structureExample = new Gson().toJson(new StructuredResponse("example message to say", !validCommands.isEmpty() ? validCommands.get(0).command : ""));
+                sb.append("The reply MUST be in this JSON format: ").append(structureExample).append("\n");
+                sb.append("The following commands are valid:\n");
+                for (TriggerCommandInfo command : validCommands) {
+                    sb.append("    ").append(command.command).append(": ").append(command.description).append("\n");
+                }
             }
 
             String system = sb.toString();
@@ -259,7 +263,7 @@ public class OpenAIChatAI implements ChatAIStrategy {
 
                     // act
                     if (message.answer().optionalCommand() != null && !message.answer().optionalCommand().isEmpty()) {
-                        Optional<TriggerCommandInfo> command = TriggerModule.findCommand(message.answer().optionalCommand());
+                        Optional<TriggerCommandInfo> command = TriggerModule.findCommand(message.answer().optionalCommand(), player, villager);
                         command.ifPresent(triggerCommandInfo -> triggerCommandInfo.call.accept(player, villager));
                     }
                 }

--- a/common/src/main/java/net/mca/entity/ai/chatAI/OpenAIChatAI.java
+++ b/common/src/main/java/net/mca/entity/ai/chatAI/OpenAIChatAI.java
@@ -218,6 +218,8 @@ public class OpenAIChatAI implements ChatAIStrategy {
 
             String system = sb.toString();
 
+            System.out.println("System: " + system);
+
             // construct body
             StringBuilder body = new StringBuilder();
             body.append("{");
@@ -250,11 +252,18 @@ public class OpenAIChatAI implements ChatAIStrategy {
             Answer message = post(config.villagerChatAIEndpoint, body.toString(), token);
 
             if (message.error == null) {
-                // remember
                 if (message.answer != null) {
+                    // remember
                     pastDialogue.add(new Pair<>("user", msg));
                     pastDialogue.add(new Pair<>("assistant", message.answer.message));
+
+                    // act
+                    if (message.answer().optionalCommand() != null && !message.answer().optionalCommand().isEmpty()) {
+                        Optional<TriggerCommandInfo> command = TriggerModule.findCommand(message.answer().optionalCommand());
+                        command.ifPresent(triggerCommandInfo -> triggerCommandInfo.call.accept(player, villager));
+                    }
                 }
+
                 return Optional.ofNullable(message.answer != null ? message.answer.message : null);
             } else if (message.error.equals("invalid_model")) {
                 player.sendMessage(Text.literal("Invalid model!").formatted(Formatting.RED), false);

--- a/common/src/main/java/net/mca/entity/ai/chatAI/inworldAIModules/TriggerCommandInfo.java
+++ b/common/src/main/java/net/mca/entity/ai/chatAI/inworldAIModules/TriggerCommandInfo.java
@@ -1,0 +1,19 @@
+package net.mca.entity.ai.chatAI.inworldAIModules;
+
+import net.mca.entity.VillagerEntityMCA;
+import net.minecraft.server.network.ServerPlayerEntity;
+
+import java.util.function.BiConsumer;
+
+// TODO: you probably want a record...
+public class TriggerCommandInfo {
+    public String command;
+    public String description;
+    public BiConsumer<ServerPlayerEntity, VillagerEntityMCA> call;
+
+    public TriggerCommandInfo(String command, String description, BiConsumer<ServerPlayerEntity, VillagerEntityMCA> call) {
+        this.command = command;
+        this.description = description;
+        this.call = call;
+    }
+}

--- a/common/src/main/java/net/mca/entity/ai/chatAI/inworldAIModules/TriggerCommandInfo.java
+++ b/common/src/main/java/net/mca/entity/ai/chatAI/inworldAIModules/TriggerCommandInfo.java
@@ -4,16 +4,22 @@ import net.mca.entity.VillagerEntityMCA;
 import net.minecraft.server.network.ServerPlayerEntity;
 
 import java.util.function.BiConsumer;
+import java.util.function.BiPredicate;
 
 // TODO: you probably want a record...
 public class TriggerCommandInfo {
     public String command;
     public String description;
+    public BiPredicate<ServerPlayerEntity, VillagerEntityMCA> isActive;
     public BiConsumer<ServerPlayerEntity, VillagerEntityMCA> call;
 
-    public TriggerCommandInfo(String command, String description, BiConsumer<ServerPlayerEntity, VillagerEntityMCA> call) {
+    public TriggerCommandInfo(String command, String description, BiConsumer<ServerPlayerEntity, VillagerEntityMCA> call, BiPredicate<ServerPlayerEntity, VillagerEntityMCA> isActive) {
         this.command = command;
         this.description = description;
         this.call = call;
+        this.isActive = isActive;
+    }
+    public TriggerCommandInfo(String command, String description, BiConsumer<ServerPlayerEntity, VillagerEntityMCA> call) {
+        this(command, description, call, (p, v) -> true);
     }
 }

--- a/common/src/main/java/net/mca/entity/ai/chatAI/inworldAIModules/TriggerModule.java
+++ b/common/src/main/java/net/mca/entity/ai/chatAI/inworldAIModules/TriggerModule.java
@@ -24,7 +24,7 @@ public class TriggerModule {
             new TriggerCommandInfo("wear-armor", "Equip any armor you have", (p, v) -> v.getVillagerBrain().setArmorWear(true)),
             new TriggerCommandInfo("remove-armor", "Remove all the armor currently equipped", (p, v) -> v.getVillagerBrain().setArmorWear(false)),
             new TriggerCommandInfo("try-go-home", "Try to go to your home in the village if possible", (p, v) -> v.getResidency().goHome(p)),
-            new TriggerCommandInfo("open-trade-window", "Lets the player trade with you", (p, v) -> v.tryBeginTradeWith(p))
+            new TriggerCommandInfo("open-trade-window", "Lets the player trade with you. Open whenever the player is interested in trading, wants to check your prices or your inventory.", (p, v) -> v.beginTradeWith(p), (p, v) -> v.hasTradeOffers())
     );
 
     /** Map for trigger name => actions */
@@ -34,9 +34,13 @@ public class TriggerModule {
                     i -> i.call
             ));
 
-    public static Optional<TriggerCommandInfo> findCommand(String command) {
+    public static Optional<TriggerCommandInfo> findCommand(String command, ServerPlayerEntity player, VillagerEntityMCA villagerEntityMCA) {
         for (TriggerCommandInfo commandInfo : triggerCommands) {
             if (command.equals(commandInfo.command)) {
+                if (commandInfo.isActive != null && !commandInfo.isActive.test(player, villagerEntityMCA)) {
+                    // not active now
+                    continue;
+                }
                 return Optional.of(commandInfo);
             }
         }

--- a/common/src/main/java/net/mca/entity/ai/chatAI/inworldAIModules/TriggerModule.java
+++ b/common/src/main/java/net/mca/entity/ai/chatAI/inworldAIModules/TriggerModule.java
@@ -8,10 +8,7 @@ import net.mca.entity.ai.chatAI.inworldAIModules.api.Interaction;
 import net.mca.entity.ai.chatAI.inworldAIModules.api.TriggerEvent;
 import net.minecraft.server.network.ServerPlayerEntity;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
@@ -26,7 +23,8 @@ public class TriggerModule {
             new TriggerCommandInfo("move-freely", "Move freely", (p, v) -> v.getVillagerBrain().setMoveState(MoveState.MOVE, p)),
             new TriggerCommandInfo("wear-armor", "Equip any armor you have", (p, v) -> v.getVillagerBrain().setArmorWear(true)),
             new TriggerCommandInfo("remove-armor", "Remove all the armor currently equipped", (p, v) -> v.getVillagerBrain().setArmorWear(false)),
-            new TriggerCommandInfo("try-go-home", "Try to go to your home in the village if possible", (p, v) -> v.getResidency().goHome(p))
+            new TriggerCommandInfo("try-go-home", "Try to go to your home in the village if possible", (p, v) -> v.getResidency().goHome(p)),
+            new TriggerCommandInfo("open-trade-window", "Lets the player trade with you", (p, v) -> v.tryBeginTradeWith(p))
     );
 
     /** Map for trigger name => actions */
@@ -35,6 +33,15 @@ public class TriggerModule {
                     i -> i.command,
                     i -> i.call
             ));
+
+    public static Optional<TriggerCommandInfo> findCommand(String command) {
+        for (TriggerCommandInfo commandInfo : triggerCommands) {
+            if (command.equals(commandInfo.command)) {
+                return Optional.of(commandInfo);
+            }
+        }
+        return Optional.empty();
+    }
 
     /**
      * Looks for outgoing triggers from the last interaction

--- a/common/src/main/java/net/mca/entity/ai/chatAI/inworldAIModules/TriggerModule.java
+++ b/common/src/main/java/net/mca/entity/ai/chatAI/inworldAIModules/TriggerModule.java
@@ -1,5 +1,6 @@
 package net.mca.entity.ai.chatAI.inworldAIModules;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import net.mca.entity.VillagerEntityMCA;
 import net.mca.entity.ai.MoveState;
@@ -7,23 +8,33 @@ import net.mca.entity.ai.chatAI.inworldAIModules.api.Interaction;
 import net.mca.entity.ai.chatAI.inworldAIModules.api.TriggerEvent;
 import net.minecraft.server.network.ServerPlayerEntity;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 /**
  * Class to manage command triggers (wear armor, follow me, etc.)
  */
 public class TriggerModule {
 
-    /** Map for trigger name => actions */
-    private static final Map<String, BiConsumer<ServerPlayerEntity, VillagerEntityMCA>> triggerActions = ImmutableMap.of(
-            "follow-player", (p, v) -> v.getVillagerBrain().setMoveState(MoveState.FOLLOW, p),
-            "stay-here", (p, v) -> v.getVillagerBrain().setMoveState(MoveState.STAY, p),
-            "move-freely", (p, v) -> v.getVillagerBrain().setMoveState(MoveState.MOVE, p),
-            "wear-armor", (p, v) -> v.getVillagerBrain().setArmorWear(true),
-            "remove-armor", (p, v) -> v.getVillagerBrain().setArmorWear(false),
-            "try-go-home", (p, v) -> v.getResidency().goHome(p)
+    public static final List<TriggerCommandInfo> triggerCommands = ImmutableList.of(
+            new TriggerCommandInfo("follow-player", "Follow the player talking to you", (p, v) -> v.getVillagerBrain().setMoveState(MoveState.FOLLOW, p)),
+            new TriggerCommandInfo("stay-here", "Stay put", (p, v) -> v.getVillagerBrain().setMoveState(MoveState.STAY, p)),
+            new TriggerCommandInfo("move-freely", "Move freely", (p, v) -> v.getVillagerBrain().setMoveState(MoveState.MOVE, p)),
+            new TriggerCommandInfo("wear-armor", "Equip any armor you have", (p, v) -> v.getVillagerBrain().setArmorWear(true)),
+            new TriggerCommandInfo("remove-armor", "Remove all the armor currently equipped", (p, v) -> v.getVillagerBrain().setArmorWear(false)),
+            new TriggerCommandInfo("try-go-home", "Try to go to your home in the village if possible", (p, v) -> v.getResidency().goHome(p))
     );
+
+    /** Map for trigger name => actions */
+    private static final Map<String, BiConsumer<ServerPlayerEntity, VillagerEntityMCA>> triggerActions =
+            triggerCommands.stream().collect(Collectors.toMap(
+                    i -> i.command,
+                    i -> i.call
+            ));
 
     /**
      * Looks for outgoing triggers from the last interaction
@@ -45,4 +56,5 @@ public class TriggerModule {
             }
         }
     }
+
 }


### PR DESCRIPTION
Organized actions a bit and made it so chat is prompted to return both message and actions with some formatting attempts, adjusting the answer to account for both (actions are optional)

Currently player2's api doesn't seem to support formatting or tooling so this method is what we're using. Should make it more flexible to other LLMs at the cost of potential issues if the model isn't up to date.