### PR TITLE
Limit config fields sent to clients during sync

### DIFF
--- a/common/src/main/java/net/conczin/mca/CommonConfig.java
+++ b/common/src/main/java/net/conczin/mca/CommonConfig.java
@@ -1,0 +1,49 @@
+package net.conczin.mca;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CommonConfig {
+
+    /**
+     * Time (in ticks) until a baby grows up when held as an item.
+     */
+    public int babyItemGrowUpTime = 24000;
+
+    /**
+     * Maximum villager lifetime in ticks (Time to grow fully up).
+     */
+    public int villagerMaxAgeTime = 384000;
+
+    /**
+     * If true, allows non-ops to add skins from the library to the server wide pool.
+     */
+    public boolean allowEveryoneToAddContentGlobally = false;
+
+    /**
+     * Allow players to modify their size.
+     */
+    public boolean allowPlayerSizeAdjustment = true;
+
+    /**
+     * Locations where the Destiny feature can teleport the player.
+     * <a href="https://github.com/Luke100000/minecraft-comes-alive/wiki/Custom-Rumors-and-Destiny-Structures">Wiki</a>
+     */
+    public List<String> destinySpawnLocations = List.of(
+            "somewhere",
+            "minecraft:shipwreck_beached",
+            "minecraft:village_desert",
+            "minecraft:village_taiga",
+            "minecraft:village_snowy",
+            "minecraft:village_plains",
+            "minecraft:village_savanna",
+            "minecraft:ancient_city"
+    );
+
+    /**
+     * Map of enabled traits. Keys are trait IDs, values are true/false.
+     */
+    public Map<String, Boolean> enabledTraits = new HashMap<>();
+
+}

--- a/common/src/main/java/net/conczin/mca/Config.java
+++ b/common/src/main/java/net/conczin/mca/Config.java
@@ -15,11 +15,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-public final class Config {
+public final class Config extends CommonConfig {
     private static final int VERSION = 2;
     private static final Config INSTANCE = loadOrCreate();
 
-    private static Config serverConfig;
+    private static CommonConfig serverConfig;
 
     @SuppressWarnings("unused")
     public String README = "https://github.com/Luke100000/minecraft-comes-alive/wiki";
@@ -185,16 +185,6 @@ public final class Config {
      * Number of hearts required to give a bouquet to a villager.
      */
     public int bouquetHeartsRequirement = 10;
-
-    /**
-     * Time (in ticks) until a baby grows up when held as an item.
-     */
-    public int babyItemGrowUpTime = 24000;
-
-    /**
-     * Maximum villager lifetime in ticks (Time to grow fully up).
-     */
-    public int villagerMaxAgeTime = 384000;
 
     /**
      * Maximum health of a villager.
@@ -611,11 +601,6 @@ public final class Config {
     public String immersiveLibraryUrl = "https://mca.conczin.net";
 
     /**
-     * If true, allows non-ops to add skins from the library to the server wide pool.
-     */
-    public boolean allowEveryoneToAddContentGlobally = false;
-
-    /**
      * Number of entries in the gift desaturation queue.
      */
     public int giftDesaturationQueueLength = 16;
@@ -745,11 +730,6 @@ public final class Config {
     public boolean allowFullPlayerEditor = false;
 
     /**
-     * Allow players to modify their size.
-     */
-    public boolean allowPlayerSizeAdjustment = true;
-
-    /**
      * Use the USA name set instead of international names.
      */
     public boolean useModernUSANamesOnly = false;
@@ -820,21 +800,6 @@ public final class Config {
     );
 
     /**
-     * Locations where the Destiny feature can teleport the player.
-     * <a href="https://github.com/Luke100000/minecraft-comes-alive/wiki/Custom-Rumors-and-Destiny-Structures">Wiki</a>
-     */
-    public List<String> destinySpawnLocations = List.of(
-            "somewhere",
-            "minecraft:shipwreck_beached",
-            "minecraft:village_desert",
-            "minecraft:village_taiga",
-            "minecraft:village_snowy",
-            "minecraft:village_plains",
-            "minecraft:village_savanna",
-            "minecraft:ancient_city"
-    );
-
-    /**
      * Maps Destiny locations to translation keys for UI text.
      */
     public Map<String, String> destinyLocationsToTranslationMap = Map.of(
@@ -867,11 +832,6 @@ public final class Config {
             "firstperson", "arms",
             "epicfight", "all"
     );
-
-    /**
-     * Map of enabled traits. Keys are trait IDs, values are true/false.
-     */
-    public Map<String, Boolean> enabledTraits = new HashMap<>();
 
     /**
      * Map of tax items to their value in units.
@@ -922,7 +882,7 @@ public final class Config {
         return config;
     }
 
-    public static Config getServerConfig() {
+    public static CommonConfig getServerConfig() {
         if (serverConfig == null) {
             return Config.getInstance();
         } else {
@@ -930,7 +890,7 @@ public final class Config {
         }
     }
 
-    public static void setServerConfig(Config config) {
+    public static void setServerConfig(CommonConfig config) {
         serverConfig = config;
     }
 

--- a/common/src/main/java/net/conczin/mca/entity/ai/brain/VillagerTasksMCA.java
+++ b/common/src/main/java/net/conczin/mca/entity/ai/brain/VillagerTasksMCA.java
@@ -200,7 +200,7 @@ public class VillagerTasksMCA {
     public static ImmutableList<Pair<Integer, ? extends BehaviorControl<? super VillagerEntityMCA>>> getImportantCorePackage(float speedModifier) {
         return ImmutableList.of(
                 Pair.of(0, new Swim(0.8F)),
-                Config.getServerConfig().useSmarterDoorAI ? Pair.of(0, new SmarterOpenDoorsTask()) : Pair.of(0, InteractWithDoor.create()),
+                Config.getInstance().useSmarterDoorAI ? Pair.of(0, new SmarterOpenDoorsTask()) : Pair.of(0, InteractWithDoor.create()),
                 Pair.of(0, new LookAtTargetSink(45, 90)),
                 Pair.of(0, WakeUp.create()),
                 Pair.of(0, new DeliverMessageTask()),

--- a/common/src/main/java/net/conczin/mca/network/s2c/ConfigResponse.java
+++ b/common/src/main/java/net/conczin/mca/network/s2c/ConfigResponse.java
@@ -1,7 +1,8 @@
 package net.conczin.mca.network.s2c;
 
-import com.google.gson.GsonBuilder;
+import com.google.gson.Gson;
 import net.conczin.mca.ClientProxy;
+import net.conczin.mca.CommonConfig;
 import net.conczin.mca.Config;
 import net.conczin.mca.MCA;
 import net.conczin.mca.network.HandleablePayload;
@@ -18,16 +19,18 @@ public record ConfigResponse(String json) implements HandleablePayload {
             ConfigResponse::new
     );
 
+    private static final Gson GSON = new Gson();
+
     public ConfigResponse(Config config) {
-        this(new GsonBuilder().setPrettyPrinting().create().toJson(config));
+        this(GSON.toJson(config, CommonConfig.class));
     }
 
-    public Config getConfig() {
+    public CommonConfig getConfig() {
         try {
-            return new GsonBuilder().setPrettyPrinting().create().fromJson(json, Config.class);
+            return GSON.fromJson(json, CommonConfig.class);
         } catch (Exception e) {
-            // Fallback to client local instance on parse errors
-            return Config.getInstance();
+            // Fallback to default values on parse errors
+            return new CommonConfig();
         }
     }
 


### PR DESCRIPTION
This PR makes just the fields needed by the client get sent during config sync.

Network and config file compatibility is maintained, however field order in `mca.json` will now have the relocated fields at the end of the file. Additionally, fixes `VillagerTasksMCA` unnecessarily using `getServerConfig()` for `useSmarterDoorAI` usage.

It may be worth adjusting documentation in code and/or of https://github.com/Luke100000/minecraft-comes-alive/wiki/Config to reflect this new organization.

Related, it seems maybe there are more places that should be using config from the server that were not previously such as `allowBodyCustomizationInDestiny` in `DestinyScreen`.

note: I have sent a message on discord with more background.