### PR TITLE
fix duplicate in checking neighbor nationality

### DIFF
--- a/common/src/main/java/net/conczin/mca/server/world/data/Nationality.java
+++ b/common/src/main/java/net/conczin/mca/server/world/data/Nationality.java
@@ -24,7 +24,7 @@ public class Nationality extends SavedData {
             {-1, 1},
             {1, 1},
             {-1, -1},
-            {-1, 1},
+            {1, -1},
     };
     final RandomSource random = RandomSource.create();
     private Map<Long, Integer> map = new HashMap<>();


### PR DESCRIPTION
when getting nationality from surroundings, the neighbors array lists `{-1, 1}` twice and does not have `{1, -1}`, causing the loop to miss that corner