### PR TITLE
Fix crashes with Productive Bees mod

### DIFF
--- a/common/src/main/java/net/conczin/mca/mixin/MixinEntityType.java
+++ b/common/src/main/java/net/conczin/mca/mixin/MixinEntityType.java
@@ -1,7 +1,8 @@
 package net.conczin.mca.mixin;
 
 import net.conczin.mca.Config;
-import net.conczin.mca.registry.EntitiesMCA;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.entity.EntityType;
 import org.spongepowered.asm.mixin.Mixin;
@@ -11,15 +12,26 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(EntityType.class)
 public class MixinEntityType {
-    @SuppressWarnings("ConstantConditions")
+    @SuppressWarnings({"ConstantConditions", "deprecation"})
     @Inject(method = "is(Lnet/minecraft/tags/TagKey;)Z", at = @At("HEAD"), cancellable = true)
     private void mca$injectIs(TagKey<EntityType<?>> tag, CallbackInfoReturnable<Boolean> cir) {
-        if (Config.getInstance().villagerTagsHacks) {
-            if ((Object) this == EntitiesMCA.MALE_VILLAGER || (Object) this == EntitiesMCA.FEMALE_VILLAGER) {
-                if (EntityType.VILLAGER.is(tag)) {
-                    cir.setReturnValue(true);
-                }
-            }
+        if (!EntityType.VILLAGER.builtInRegistryHolder().is(tag)) {
+            return;
         }
+
+        if (mca$isCustomVillagerType()) {
+            cir.setReturnValue(true);
+        }
+    }
+
+    private boolean mca$isCustomVillagerType() {
+        if (!Config.getInstance().villagerTagsHacks) {
+            return false;
+        }
+
+        ResourceLocation id = BuiltInRegistries.ENTITY_TYPE.getKey((EntityType<?>) (Object) this);
+        return id != null
+                && "mca".equals(id.getNamespace())
+                && ("male_villager".equals(id.getPath()) || "female_villager".equals(id.getPath()));
     }
 }

--- a/common/src/main/resources/data/minecraft/tags/entity_type/villager.json
+++ b/common/src/main/resources/data/minecraft/tags/entity_type/villager.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:villager",
+    "mca:male_villager",
+    "mca:female_villager"
+  ]
+}


### PR DESCRIPTION
Fixes the Productive Bees crash caused by MCA's villager tag hack touching MCA entity registration too late during `EntityType.is()` checks.

Instead of checking `EntitiesMCA.MALE_VILLAGER` / `FEMALE_VILLAGER` inside the mixin, the mixin now checks the current entity type by registry id. That keeps the old broad compatibility behavior for tags that include vanilla villagers, including tags from other mods, without forcing MCA entity init during startup.

Also adds a normal data tag for `#minecraft:villager` with:

- `minecraft:villager`
- `mca:male_villager`
- `mca:female_villager`

So mods/datapacks can use the clean tag path too. The existing `villagerTagsHacks` config option is still there and still controls the compatibility hook.