### PR TITLE
Treat bouquets as normal gifts when the receiver is already in a relationship with the player

### DIFF
--- a/common/src/main/java/net/conczin/mca/entity/ai/BreedableRelationship.java
+++ b/common/src/main/java/net/conczin/mca/entity/ai/BreedableRelationship.java
@@ -6,6 +6,7 @@ import net.conczin.mca.entity.Status;
 import net.conczin.mca.entity.VillagerEntityMCA;
 import net.conczin.mca.entity.interaction.gifts.GiftType;
 import net.conczin.mca.entity.interaction.gifts.Response;
+import net.conczin.mca.item.BouquetItem;
 import net.conczin.mca.item.SpecialCaseGift;
 import net.conczin.mca.network.Network;
 import net.conczin.mca.network.s2c.AnalysisResults;
@@ -210,7 +211,11 @@ public class BreedableRelationship extends Relationship<VillagerEntityMCA> {
 
         if (item instanceof SpecialCaseGift) {
             if (((SpecialCaseGift) item).handle(player, entity)) {
-                stack.shrink(1);
+                if ((item instanceof BouquetItem) && (Relationship.IS_MARRIED.test(entity, player) || Relationship.IS_ROMANTIC_PARTNER.test(entity, player))) {
+                    return false;
+                } else {
+                    stack.shrink(1);
+                }
             }
             return true;
         }

--- a/common/src/main/java/net/conczin/mca/item/BouquetItem.java
+++ b/common/src/main/java/net/conczin/mca/item/BouquetItem.java
@@ -2,6 +2,7 @@ package net.conczin.mca.item;
 
 import net.conczin.mca.Config;
 import net.conczin.mca.entity.VillagerEntityMCA;
+import net.conczin.mca.entity.ai.Relationship;
 import net.conczin.mca.server.world.data.PlayerSaveData;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.Item;
@@ -20,6 +21,11 @@ public class BouquetItem extends RelationshipItem {
     public boolean handle(ServerPlayer player, VillagerEntityMCA villager) {
         PlayerSaveData playerData = PlayerSaveData.get(player);
         String response;
+
+        //If gifted to partner or spouse then return as a valid gift
+        if (Relationship.IS_MARRIED.test(villager, player) || Relationship.IS_ROMANTIC_PARTNER.test(villager, player)) {
+            return true;
+        }
 
         if (super.handle(player, villager)) {
             return false;

--- a/common/src/main/resources/data/mca/gifts/flowers.json
+++ b/common/src/main/resources/data/mca/gifts/flowers.json
@@ -12,6 +12,7 @@
     "best": "gift.flowers.best"
   },
   "items": {
-    "#minecraft:flowers": 5
+    "#minecraft:flowers": 5,
+    "mca:bouquet": 30
   }
 }


### PR DESCRIPTION
## Summary

Normally, giving a bouquet to a villager who is already in a relationship with the player is interpreted as a new romantic proposal, so they refuse the gift.

I decided to change that behavior. If the receiver is already the player's partner, the bouquet is treated as a normal gift instead of a proposal.

## Additional changes

- Added the bouquet to `flower.json` with a satisfaction value of `30`, as it is effectively a large flower. Or we could decrease the value, but still keeping it as best gift.

## Notes

I tried to avoid checking the relationship status twice, but I couldn't find a cleaner way with the current code structure. If there is a better approach, I'd be happy to update the implementation.