### PR TITLE
Fix: Family tree search to fallback to player name

### DIFF
--- a/common/src/main/java/net/conczin/mca/client/gui/FamilyTreeSearchScreen.java
+++ b/common/src/main/java/net/conczin/mca/client/gui/FamilyTreeSearchScreen.java
@@ -66,18 +66,13 @@ public class FamilyTreeSearchScreen extends Screen {
         buttonPage = addRenderableWidget(new ButtonWidget(width / 2 - 24, height / 2 + 60, 48, 20, Component.literal("1/1"), (b) -> {
         }));
 
-        assert minecraft != null;
-        if (minecraft.player != null) {
-            String playerUUID = minecraft.player.getName().getString();
-            searchVillager(playerUUID);
-        }
+        searchVillager("");
     }
 
     @Override
     public void render(GuiGraphics context, int mouseX, int mouseY, float delta) {
         renderBackground(context, mouseX, mouseY, delta);
 
-        assert minecraft != null;
         this.mouseX = (int) (minecraft.mouseHandler.xpos() * width / minecraft.getWindow().getWidth());
         this.mouseY = (int) (minecraft.mouseHandler.ypos() * height / minecraft.getWindow().getHeight());
 
@@ -122,11 +117,15 @@ public class FamilyTreeSearchScreen extends Screen {
         }
     }
 
-    private void searchVillager(String v) {
-        if (!MCA.isBlankString(v)) {
-            Network.sendToServer(new FamilyTreeUUIDLookup(v));
+    private void searchVillager(String value) {
+        String search = value;
+        if (MCA.isBlankString(search) && minecraft.player != null) {
+            search = minecraft.player.getName().getString();
         }
 
+        if (!MCA.isBlankString(search)) {
+            Network.sendToServer(new FamilyTreeUUIDLookup(search));
+        }
     }
 
     public void setList(List<FamilyTreeSearchEntry> list) {
@@ -148,7 +147,6 @@ public class FamilyTreeSearchScreen extends Screen {
     }
 
     void selectVillager(String name, UUID villager) {
-        assert minecraft != null;
         minecraft.setScreen(new FamilyTreeScreen(villager));
     }
 

--- a/common/src/main/java/net/conczin/mca/client/gui/FamilyTreeSearchScreen.java
+++ b/common/src/main/java/net/conczin/mca/client/gui/FamilyTreeSearchScreen.java
@@ -65,6 +65,12 @@ public class FamilyTreeSearchScreen extends Screen {
         }));
         buttonPage = addRenderableWidget(new ButtonWidget(width / 2 - 24, height / 2 + 60, 48, 20, Component.literal("1/1"), (b) -> {
         }));
+
+        assert minecraft != null;
+        if (minecraft.player != null) {
+            String playerUUID = minecraft.player.getName().getString();
+            searchVillager(playerUUID);
+        }
     }
 
     @Override
@@ -120,13 +126,7 @@ public class FamilyTreeSearchScreen extends Screen {
         if (!MCA.isBlankString(v)) {
             Network.sendToServer(new FamilyTreeUUIDLookup(v));
         }
-        else {
-            assert minecraft != null;
-            if (minecraft.player != null) {
-                UUID playerUUID = minecraft.player.getUUID();
-                Network.sendToServer(new FamilyTreeUUIDLookup(playerUUID));
-            }
-        }
+
     }
 
     public void setList(List<FamilyTreeSearchEntry> list) {

--- a/common/src/main/java/net/conczin/mca/client/gui/FamilyTreeSearchScreen.java
+++ b/common/src/main/java/net/conczin/mca/client/gui/FamilyTreeSearchScreen.java
@@ -120,6 +120,13 @@ public class FamilyTreeSearchScreen extends Screen {
         if (!MCA.isBlankString(v)) {
             Network.sendToServer(new FamilyTreeUUIDLookup(v));
         }
+        else {
+            assert minecraft != null;
+            if (minecraft.player != null) {
+                UUID playerUUID = minecraft.player.getUUID();
+                Network.sendToServer(new FamilyTreeUUIDLookup(playerUUID));
+            }
+        }
     }
 
     public void setList(List<FamilyTreeSearchEntry> list) {


### PR DESCRIPTION
<img width="278" height="428" alt="image" src="https://github.com/user-attachments/assets/55584b9c-8bc6-4fc4-b367-b555f3e0a7bf" />

## Testing
- Tested with `runClient` in dev environment
- Verified empty search shows player's family tree
- Verified typed search still works

## Why
Players frequently check their own family tree, so defaulting to the player's own tree when the search box is empty saves time and eliminates the need to type their name each time.